### PR TITLE
Hydra v0.0.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ If both of these ratios surpass certain predetermined threshold values, this sug
 
 The thresholds are determined as the lowest value calculated by Hydra from 6 confirmed positive cases. They are:
 
-- exon 3: 1.1793
-- exons 3 & 5: 2.28548
+- exon 3 / exon 27: 1.1793
+- (exon 3 + exon 5) / exon 27: 2.28548
 
 This app is intended for inclusion in the Uranus workflow for somatic variant calling in haematological oncology cases.
 
@@ -21,6 +21,8 @@ dx run (app id) -ihydra_input_project=(project id or name) -y
 The app takes one non-optional input argument, hydra_input_project, which is the name or object ID of a DNAnexus project.
 
 It returns as output a single .tsv file, which lists the mean coverage values for exons 3, 5 and 27, the ratios described above, and whether or not each ratio is above the threshold, for each sample in the project which has an exon_stats.tsv file. If a file is archived, no data will be returned.
+
+The final column in the output workbook lists whether any of exons 3, 5 or 27 have less than 90% coverage at 250x, which is a QC threshold used in the Uranus pipeline.
 
 ## References
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,16 @@
 # eggd_hydra app
 
-Given the name or ID of a DNAnexus project, this app identifies all exon_stats.tsv files within that project and calculates the ratio of exon 3 to exon 27 mean coverage in the KMT2A gene. If this ratio surpasses a threshold value this suggests the possible presence of a partial tandem duplication (KMT2A-PTD) in that sample.
+Given the name or ID of a DNAnexus project, this app identifies all exon_stats.tsv files within that project and calculates ratios of mean exon coverage in the KMT2A gene:
 
-The coverage ratio threshold currently in use is 1.1793, which is the lowest value calculated by Hydra from 6 confirmed positive cases.
+- exon 3 / exon 27
+- (exon 3 + exon 5) / exon 27
+
+If both of these ratios surpass certain predetermined threshold values, this suggests the possible presence of a partial tandem duplication (KMT2A-PTD) in that sample.
+
+The thresholds are determined as the lowest value calculated by Hydra from 6 confirmed positive cases. They are:
+
+- exon 3: 1.1793
+- exons 3 & 5: 2.28548
 
 This app is intended for inclusion in the Uranus workflow for somatic variant calling in haematological oncology cases.
 
@@ -12,7 +20,7 @@ dx run (app id) -ihydra_input_project=(project id or name) -y
 
 The app takes one non-optional input argument, hydra_input_project, which is the name or object ID of a DNAnexus project.
 
-It returns as output a single .tsv file, which lists the mean coverage values for exons 3 and 27, the ratio of one to the other, and whether or not this ratio is above the threshold, for each sample in the project which has an exon_stats.tsv file. If a file is archived, no data will be returned.
+It returns as output a single .tsv file, which lists the mean coverage values for exons 3, 5 and 27, the ratios described above, and whether or not each ratio is above the threshold, for each sample in the project which has an exon_stats.tsv file. If a file is archived, no data will be returned.
 
 ## References
 

--- a/dxapp.json
+++ b/dxapp.json
@@ -1,6 +1,6 @@
 {
-    "name": "eggd_hydra",
-    "title": "eggd_hydra",
+    "name": "eggd_hydra_v0.0.2",
+    "title": "eggd_hydra_v0.0.2",
     "summary": "Calculates fold-change ratio for KMT2A PTDs",
     "description": "Given the name of a DNAnexus project, calculates the ratio of exon 3 mean coverage to exon 27 mean coverage in the KMT2A gene for each sample.",
     "tags": [

--- a/src/code.sh
+++ b/src/code.sh
@@ -7,8 +7,8 @@ main() {
 
     dx-download-all-inputs
 
-    # get ids of all exon_stats files for that project
-    coverage_files=$(dx find data \
+    # get ids of all exon_stats files for the project
+    file_ids=$(dx find data \
     --name "*exon_stats.tsv" \
     --project "$hydra_input_project" \
     --brief)
@@ -18,37 +18,59 @@ main() {
     output_file="${output_dir}hydra_output_${hydra_input_project}.tsv"
 
     mkdir -p "$output_dir"
-    printf "sample\texon_3\texon_27\tratio\tover_threshold\n" > "$output_file"
+    printf "sample\texon_3\texon_5\texon_27\tratio_3_only\tratio_3_and_5\tpass_3_only\tpass_3_and_5\tpass_overall\t250x_issue\n" > "$output_file"
 
-    for coverage_file in $coverage_files; do
+    # evaluate each exon_stats file against exon coverage thresholds
+    for file_id in $file_ids; do
 
-        # get the file name, sample id, and archival state
-        state=$(dx describe "$coverage_file" --json | jq -r '.archivalState')
-        file_name=$(dx describe "$coverage_file" --json | jq -r '.name')
+        # get file name, sample id, and archival state
+        state=$(dx describe "$file_id" --json | jq -r '.archivalState')
+        file_name=$(dx describe "$file_id" --json | jq -r '.name')
         sample_id="${file_name%%_exon_stats.tsv}"
 
         if [[ "$state" == "live" ]]; then
 
             # download the file if it isn't archived
-            dx download "$coverage_file" -f
+            dx download "$file_id" -f
 
-            # get mean coverage values for exons 3 and 27
-            exon3=$(awk -F"\t" '$4 == "KMT2A" && $6 == "3" {print $8}' "$file_name")
-            exon27=$(awk -F"\t" '$4 == "KMT2A" && $6 == "27" {print $8}' "$file_name")
+            # check all exons of interest have >90% at 250x coverage
+            cov_issues=""
+            for exon in "3" "5" "27"; do
+                cov_250=$(awk -F"\t" -v exon="$exon" '$4=="KMT2A" && $6==exon {print $11}' "$file_name")
+                if (( $cov_250 <= 90 )); then
+                    cov_issues="${cov_issues}${exon} "
+                fi
+            done
 
-            # divide the two together
-            coverage_ratio=$(bc <<< "scale=5 ; $exon3 / $exon27")
+            # get mean coverage for exons of interest
+            exon_3=$(awk -F"\t" '$4 == "KMT2A" && $6 == "3" {print $8}' "$file_name")
+            exon_5=$(awk -F"\t" '$4 == "KMT2A" && $6 == "5" {print $8}' "$file_name")
+            exon_27=$(awk -F"\t" '$4 == "KMT2A" && $6 == "27" {print $8}' "$file_name")
 
-            # compare ratio to threshold
-            if [[ $(bc -l <<< "$coverage_ratio >= 1.1793") -eq 1 ]]; then
-                over_threshold=true
-            else
-                over_threshold=false
+            # calculate ratios
+            ratio_3_only=$(bc <<< "scale=5 ; $exon_3 / $exon_27")
+            ratio_3_and_5=$(bc <<< "scale=5 ; ($exon_3 + $exon_5) / $exon_27")
+
+            # compare ratios to thresholds
+            pass_3_only=false
+            pass_3_and_5=false
+            pass_overall=false
+
+            if [[ $(bc -l <<< "$ratio_3_only >= 1.1793") -eq 1  ]]; then
+                pass_3_only=true
+            fi
+
+            if [[ $(bc -l <<< "$ratio_3_and_5 >= 2.28548") -eq 1 ]]; then
+                pass_3_and_5=true
+            fi
+
+            if [[ "$pass_3_only" == true ]] && [[ "$pass_3_and_5" == true ]]; then
+                pass_overall=true
             fi
 
             # add to output file
-            printf "%s\t%f\t%f\t%f\t%s\n" \
-            "$sample_id" "$exon3" "$exon27" "$coverage_ratio" "$over_threshold" \
+            printf "%s\t%f\t%f\t%f\t%f\t%f\t%s\t%s\t%s\t%s\n" \
+            "$sample_id" "$exon_3" "$exon_5" "$exon_27" "$ratio_3_only" "$ratio_3_and_5" "$pass_3_only" "$pass_3_and_5" "$pass_overall" "$cov_issues" \
             >> "$output_file"
 
         else


### PR DESCRIPTION
A sample now has to have two separate exon coverage ratios pass independent thresholds before it is considered a potential positive for a KMT2A-PTD.

A QC check to ensure that all relevant exons have >90% coverage at 250x has been included.

Full documentation of changes at https://cuhbioinformatics.atlassian.net/wiki/spaces/URA/pages/3045458090/231205+eggd+hydra+v0.0.2